### PR TITLE
checking mtime rather than ino in fileWatcher

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ exports.watchTree = function ( root, options, callback ) {
     var fileWatcher = function (f) {
       fs.watchFile(f, options, function (c, p) {
         // Check if anything actually changed in stat
-        if (files[f] && !files[f].isDirectory() && c.nlink !== 0 && files[f].ino == c.ino) return;
+        if (files[f] && !files[f].isDirectory() && c.nlink !== 0 && files[f].mtime == c.mtime) return;
         files[f] = c;
         if (!files[f].isDirectory()) callback(f, c, p);
         else {

--- a/test/test_monitor.js
+++ b/test/test_monitor.js
@@ -1,15 +1,31 @@
 var watch = require('../main')
   , assert = require('assert')
+  , path = require('path')
+  , fs = require('fs')
+  , target = path.join(__dirname, "d/t")
   ;
 
-watch.createMonitor(__dirname, function (monitor) {
-  monitor.on('created', function (f) {
-    console.log('created '+f)
-  })
-  monitor.on('removed', function (f) {
-    console.log('removed '+f)
-  })
-  monitor.on('changed', function (f) {
-    console.log('changed '+f)
-  })
+function clearFile() {
+  fs.writeFileSync(target, '')
+}
+
+clearFile()
+
+// test if changed event is fired correctly
+watch.createMonitor(__dirname, { interval: 150 },
+  function (monitor) {
+    monitor.once('changed', function (f) {
+      assert.equal(f, target);
+      clearFile();
+      process.exit(0)
+    })
+
+    fs.writeFile(target, 'Test Write\n', function (err) {
+      if (err) throw err;
+
+      setTimeout(function () {
+        // should have got the other assert done by now
+        assert.ok(false);
+      }, 300);
+    })
 });


### PR DESCRIPTION
I wasn't seeing the `changed` event fire when using `createMonitor` - not sure if there's a better reason for checking `ino` that I overlooked.
