### PR TITLE
Add homepage, bugs, and repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
 , "description" : "Utilities for watching file trees."
 , "tags" : ["util", "utility", "fs", "files"]
 , "version" : "0.3.2"
+, "homepage": "https://github.com/mikeal/watch"
+, "bugs":
+  { "web": "https://github.com/mikeal/watch/issues" }
+, "repository": { "type": "git"
+  , "url": "git://github.com/mikeal/watch.git"
+  }
 , "author" : "Mikeal Rogers <mikeal.rogers@gmail.com>"
 , "directories" :
   { "lib" : "lib" }


### PR DESCRIPTION
This package is _very_ hard to find using Google, but it is rather easy to find using http://search.npmjs.org/. So I added homepage etc. to package.json so that it is easy to navigate here from search.npmjs.org.
