### PR TITLE
Fix for date match failing

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,7 +55,7 @@ exports.watchTree = function ( root, options, callback ) {
     var fileWatcher = function (f) {
       fs.watchFile(f, options, function (c, p) {
         // Check if anything actually changed in stat
-        if (files[f] && !files[f].isDirectory() && c.nlink !== 0 && files[f].mtime == c.mtime) return;
+        if (files[f] && !files[f].isDirectory() && c.nlink !== 0 && files[f].mtime.getTime() == c.mtime.getTime()) return;
         files[f] = c;
         if (!files[f].isDirectory()) callback(f, c, p);
         else {


### PR DESCRIPTION
I'm using watch via the forever script, and that was detecting all files in my working copy as changed (even though none were - https://github.com/indexzero/forever/issues/129).

I tracked it down to watch seemingly incorrectly matching dates.  Even though the dates are the same the == comparison fails.  I don't know what the cause of this is, I suppose it's false because they're not the same date object, I can reproduce it with this script...

``` javascript
var x = new Date();
var y = new Date();

if ( x == y ) { 
    console.log( 'Equality matched!' );
}

if ( x.getTime() == y.getTime() ) { 
    console.log( 'getTime() matched!' );
}
```

Only the second will match, haven't tried this on any other system (i'm on osx with node 0.4.11).
