### PR TITLE
Fixing no callback when final pending file is ignored

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,10 +35,15 @@ function walk (dir, options, callback) {
         fs.stat(f, function (err, stat) {
           if (err) return callback(err)
           callback.pending -= 1;
-          if (!(options.ignoreDotFiles && path.basename(f)[0] === '.' || options.filter && options.filter(f))) {
+
+          var ignored = options.ignoreDotFiles && path.basename(f)[0] === '.',
+              filtered = options.filter && options.filter(f); 
+          
+          if (!(ignored || filtered)) {
               callback.files[f] = stat;
               if (stat.isDirectory()) walk(f, options, callback);
           }
+
           if (callback.pending === 0) callback(null, callback.files);
         })
       })


### PR DESCRIPTION
The callback I passed to watchTree never got called. I tracked it down to the case where options.filter is used and the very last pending directory is ignored. This causes the inner most function in the walk function to return without error or invoking the callback. This is my fix for it.
