### PR TITLE
Check enoent

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,8 +34,13 @@ function walk (dir, options, callback) {
         callback.pending += 1;
         fs.stat(f, function (err, stat) {
           var enoent = false;
-          if (err && (err.code === 'ENOENT')) { enoent = true; }
-          if (err && !enoent) return callback(err)
+          if (err) {
+            if (err.code !== 'ENOENT') {
+              return callback(err);
+            } else {
+              enoent = true;
+            }
+          }
           callback.pending -= 1;
           if (!enoent) {
             if (options.ignoreDotFiles && path.basename(f)[0] === '.') return;


### PR DESCRIPTION
As part of the `walk` logic, files should be checked with `fs.stat`. If `fs.stat` returns with an error, then if the code is not `'ENOENT'` pass the error on to the `callback`; if it is `'ENOENT'`, then effectively skip the file in question.

This will allow `watch` to avoid throwing exceptions when encountering, for example, the temporary symbolic links created by Emacs when a file is being modified.
