### PR TITLE
fixing the global declaration of variable 'i' in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -90,7 +90,7 @@ exports.watchTree = function ( root, options, callback ) {
       })
     }
     fileWatcher(root);
-    for (i in files) {
+    for (var i in files) {
       fileWatcher(i);
     }
     callback(files, null, null);


### PR DESCRIPTION
"i" was declared in a loop without first scoping it locally - minor fix.
