### PR TITLE
Fixed comment placement in createMonitor example

### DIFF
--- a/readme.mkd
+++ b/readme.mkd
@@ -59,10 +59,10 @@ The monitor has the following events.
   watch.createMonitor('/home/mikeal', function (monitor) {
     monitor.files['/home/mikeal/.zshrc'] // Stat object for my zshrc.
     monitor.on("created", function (f, stat) {
-      // Handle file changes
+      // Handle new files
     })
     monitor.on("changed", function (f, curr, prev) {
-      // Handle new files
+      // Handle file changes
     })
     monitor.on("removed", function (f, stat) {
       // Handle removed files


### PR DESCRIPTION
I was a bit confused while reading those instructions, until I noticed the comments were the wrong way around. :-)