### PR TITLE
ignoreDotFiles not working as expected

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,7 +75,7 @@ exports.watchTree = function ( root, options, callback ) {
             if (err) return;
             nfiles.forEach(function (b) {
               var file = path.join(f, b);
-              if (!files[file]) {
+              if (!files[file] && (options.ignoreDotFiles !== true || b[0] != '.')) {
                 fs.stat(file, function (err, stat) {
                   callback(file, stat, null);
                   files[file] = stat;


### PR DESCRIPTION
Newly created dot files were throwing "Created" events when ignoreDotFiles was true. I was seeing this on OSX with .DS_Store files anytime any other file in the folder was edited
