### PR TITLE
watchTest filter option inverts typical filter function usage.  test + pull request included.

### DIFF
--- a/main.js
+++ b/main.js
@@ -47,7 +47,7 @@ function walk (dir, options, callback) {
           done = callback.pending === 0;
           if (!enoent) {
             if (options.ignoreDotFiles && path.basename(f)[0] === '.') return done && callback(null, callback.files);
-            if (options.filter && options.filter(f, stat)) return done && callback(null, callback.files);
+            if (options.filter && !options.filter(f, stat)) return done && callback(null, callback.files);
             callback.files[f] = stat;
             if (stat.isDirectory()) walk(f, options, callback);
             done = callback.pending === 0;

--- a/test/test_watchTree.js
+++ b/test/test_watchTree.js
@@ -1,9 +1,20 @@
-var watch = require('../main')
+var fs = require('fs')
+  , watch = require('../main')
   , assert = require('assert')
   ;
 
-watch.watchTree(__dirname, function (f, curr, prev) {
-  // console.log('file '+f+' prev '+prev+' curr '+curr);
-  // console.dir(curr)
-  // console.dir(prev)
+//
+// Demonstrate that the function of 'filter' is semantically inconsistent with
+// usual convention, that returning true means 'keep this'.
+//
+function isDirOrQ(f, stat) { return stat.isDirectory() || f === 'Q'; }
+
+watch.watchTree(__dirname, { filter: isDirOrQ }, function (f, curr, prev) {
+  if (typeof f == 'object' && prev === null && curr === null) {
+    Object.keys(f).forEach(function(name) {
+      var stat = f[name];
+      assert(isDirOrQ(name, stat));
+      fs.unwatchFile(name);
+    });
+  }
 });


### PR DESCRIPTION
The filter option to watchTree is used in an inverted fashion compared to the normal use of a filter function.  Perhaps this is intentional, but in any case, unintuitive.  Included is both a small test to demonstrate, and the 1 character fix.
