### PR TITLE
added check to see if curr is still valid.

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,10 +135,13 @@ exports.createMonitor = function (root, options, cb) {
     if (prevFile.file === null) {
       monitor.emit("changed", f, curr, prev);
     }
-    if (prevFile.stat && curr.mtime) {
+    // stat might return null, so catch errors
+    try {
       if (prevFile.stat.mtime.getTime() !== curr.mtime.getTime()) {
         monitor.emit("changed", f, curr, prev);
       }
+    } catch(e) {
+      monitor.emit("changed", f, curr, prev);
     }
   })
 }


### PR DESCRIPTION
Emacs temp files can cause curr to be null during the check. This just adds an extra check before assuming it exists.
