### PR TITLE
Skip unreadable dir

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ function walk (dir, options, callback) {
     callback.files[dir] = stat;
     fs.readdir(dir, function (err, files) {
       if (err) {
-        if(err.code === 'EACCES' && options.ignoreUnreadableFiles) return callback();
+        if(err.code === 'EACCES' && options.ignoreUnreadableDir) return callback();
         return callback(err);
       }
       callback.pending -= 1;

--- a/readme.mkd
+++ b/readme.mkd
@@ -18,7 +18,7 @@ The options object is passed to fs.watchFile but can also be used to provide two
 
 * `'ignoreDotFiles'` - When true this option means that when the file tree is walked it will ignore files that being with "."
 * `'filter'` - You can use this option to provide a function that returns true or false for each file and directory that is walked to decide whether or not that file/directory is included in the watcher.
-* `'ignoreUnreadableFiles'` - When true, this options means that when a file can't be read, this file is silently skipped.
+* `'ignoreUnreadableDir'` - When true, this options means that when a file can't be read, this file is silently skipped.
 
 The callback takes 3 arguments. The first is the file that was modified. The second is the current stat object for that file and the third is the previous stat object.
 


### PR DESCRIPTION
Skip silently the dir instead of return an error when a dir is not readable.
