### PR TITLE
Added optional parameter to filter directory by regex

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,7 +52,7 @@ function walk (dir, options, callback) {
             if (options.ignoreDotFiles && path.basename(f)[0] === '.') return done && callback(null, callback.files);
             if (options.filter && !options.filter(f, stat)) return done && callback(null, callback.files);
             callback.files[f] = stat;
-            if (stat.isDirectory()) walk(f, options, callback);
+            if (stat.isDirectory() && !(options.ignoreDirectoryPattern && options.ignoreDirectoryPattern.test(f))) walk(f, options, callback);
             done = callback.pending === 0;
             if (done) callback(null, callback.files);
           }

--- a/readme.mkd
+++ b/readme.mkd
@@ -19,6 +19,7 @@ The options object is passed to fs.watchFile but can also be used to provide two
 * `'ignoreDotFiles'` - When true this option means that when the file tree is walked it will ignore files that being with "."
 * `'filter'` - You can use this option to provide a function that returns true or false for each file and directory that is walked to decide whether or not that file/directory is included in the watcher.
 * `'ignoreUnreadableDir'` - When true, this options means that when a file can't be read, this file is silently skipped.
+* `'ignoreDirectoryPattern'` - When a regex pattern is set, e.g. /node_modules/, these directories are silently skipped.
 
 The callback takes 3 arguments. The first is the file that was modified. The second is the current stat object for that file and the third is the previous stat object.
 


### PR DESCRIPTION
Added this to allow us to ignore node_modules for performance reasons, made it generic as it may be more useful to others this way.  Can't get the tests to run as they are, so haven't written a test for this - shout if you want me to have another go at it.
