### PR TITLE
Gracfully handle not authorized file acces

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ function walk (dir, options, callback) {
             , done = false;
 
           if (err) {
-            if (err.code !== 'ENOENT') {
+            if (err.code !== 'ENOENT' && (err.code !== 'EPERM' && options.ignoreNotPermitted)) {
               return callback(err);
             } else {
               enoent = true;

--- a/readme.mkd
+++ b/readme.mkd
@@ -19,6 +19,7 @@ The options object is passed to fs.watchFile but can also be used to provide two
 * `'ignoreDotFiles'` - When true this option means that when the file tree is walked it will ignore files that being with "."
 * `'filter'` - You can use this option to provide a function that returns true or false for each file and directory that is walked to decide whether or not that file/directory is included in the watcher.
 * `'ignoreUnreadableDir'` - When true, this options means that when a file can't be read, this file is silently skipped.
+* `'ignoreNotPermitted'` - When true, this options means that when a file can't be read due to permission issues, this file is silently skipped.
 * `'ignoreDirectoryPattern'` - When a regex pattern is set, e.g. /node_modules/, these directories are silently skipped.
 
 The callback takes 3 arguments. The first is the file that was modified. The second is the current stat object for that file and the third is the previous stat object.


### PR DESCRIPTION
Prevent app from crushing when a not authorized file is accessed, causing an EPPRM error.