### PR TITLE
Simplified last modified check solving double event emission on OSX

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,7 +74,7 @@ exports.watchTree = function ( root, options, callback ) {
     var fileWatcher = function (f) {
       fs.watchFile(f, options, function (c, p) {
         // Check if anything actually changed in stat
-        if (p.mtime.getTime() == c.mtime.getTime()) return;
+        if (files[f] && p.mtime.getTime() == c.mtime.getTime()) return;
         files[f] = c;
         if (!files[f].isDirectory()) callback(f, c, p);
         else {


### PR DESCRIPTION
I couldn't figure out the reason why there are checks for `isDirectory` or `nlink` so I removed them, because in any case, when the current `mtime` is equal to the previous `mtime` the function should return because that means there are no modification to the file. Right?

This should fix issue #48. I ran the test for the tree, and didn't error so I guess this should not break anything. 
