### PR TITLE
Apply filter to newly created files

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,6 +84,7 @@ exports.watchTree = function ( root, options, callback ) {
               var file = path.join(f, b);
               if (!files[file] && (options.ignoreDotFiles !== true || b[0] != '.')) {
                 fs.stat(file, function (err, stat) {
+                  if (options.filter && !options.filter(file, stat)) return;
                   callback(file, stat, null);
                   files[file] = stat;
                   fileWatcher(file);

--- a/readme.mkd
+++ b/readme.mkd
@@ -17,7 +17,7 @@ The first argument is the directory root you want to watch.
 The options object is passed to fs.watchFile but can also be used to provide two additional watchTree specific options:
 
 * `'ignoreDotFiles'` - When true this option means that when the file tree is walked it will ignore files that being with "."
-* `'filter'` - You can use this option to provide a function that returns true or false for each file and directory that is walked to decide whether or not that file/directory is included in the watcher.
+* `'filter'` - You can use this option to provide a function that returns true or false for each file and directory to decide whether or not that file/directory is included in the watcher.
 * `'ignoreUnreadableDir'` - When true, this options means that when a file can't be read, this file is silently skipped.
 * `'ignoreDirectoryPattern'` - When a regex pattern is set, e.g. /node_modules/, these directories are silently skipped.
 


### PR DESCRIPTION
This applies the filter function to new files. 

Currently the filter is only applied on the initial walk. This causes filtered-out files to be watched after they're edited at least once.

For example, I have a filtered-out file called "built.js" with compiled javascript. When I fs.writeFile to built.js, it's detected as a new file and is watched from that point forward, thereby bypassing the filter function.

Thoughts on this?
