### PR TITLE
Add a couple boolean ignore options to CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,15 +9,22 @@ if(argv._.length === 0) {
   process.exit()
 }
 
+var watchTreeOpts = {}
 var command = argv._[0]
 var dir = argv._[1] || process.cwd()
 var waitTime = Number(argv.wait || argv.w)
+
+if(argv.ignoreDotFiles || argv.d)
+  watchTreeOpts.ignoreDotFiles = true
+
+if(argv.ignoreUnreadable || argv.u)
+  watchTreeOpts.ignoreUnreadableDir = true
 
 console.error('> Watching', dir)
 
 var wait = false
 
-watch.watchTree(dir, function (f, curr, prev) {
+watch.watchTree(dir, watchTreeOpts, function (f, curr, prev) {
   if(wait) return
 
   execshell(command)

--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ var execshell = require('exec-sh')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [directory] [--wait=<seconds>]')
+  console.error('Usage: watch <command> [directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable]')
   process.exit()
 }
 

--- a/readme.mkd
+++ b/readme.mkd
@@ -95,11 +95,11 @@ OPTIONS:
         throttle calls to <command> for the specified duration.
 
     --ignoreDotFiles, -d
-        Ignores dot or hidden files in watch target.
+        Ignores dot or hidden files in the watch [directory].
 
      --ignoreUnreadable, -u
         Silently ignores files that cannot be read within the
-        watch target.
+        watch [directory].
 ```
 
 It will watch the given directory (defaults to the current working directory) with `watchTree` and run the given command every time a file changes.

--- a/readme.mkd
+++ b/readme.mkd
@@ -84,11 +84,22 @@ The monitor can be stopped using `.stop` (calls `unwatchTree`).
 
 This module includes a simple command line interface, which you can install with `npm install watch -g`.
 
+
 ```
-Usage: watch <command> [directory] [--wait=<seconds>]
+Usage: watch <command> [directory] [OPTIONS]
+
+OPTIONS:
+    --wait=<seconds>
+        Duration, in seconds, that watching will be disabled
+        after running <command>. Setting this option will
+        throttle calls to <command> for the specified duration.
+
+    --ignoreDotFiles, -d
+        Ignores dot or hidden files in watch target.
+
+     --ignoreUnreadable, -u
+        Silently ignores files that cannot be read within the
+        watch target.
 ```
 
-It will watch the given directory (defaults to the current working directory) with `watchTree` and run
-the given command every time a file changes. The optional `wait` parameter specifies a time in seconds
-that the watching will be disabled after running a command.
-
+It will watch the given directory (defaults to the current working directory) with `watchTree` and run the given command every time a file changes.


### PR DESCRIPTION
With the return of simple npm run build systems, I find myself reaching more and more for watch utilities with configurable CLI's. So far in my current workflows and stacks, I find that the only thing really missing in this CLI is just the exposure of the `watchTree` option `ignoreDotFiles `.

This is just a quick PR to see if I could get those exposed, so that this could be a thing:
```json
"scripts": {
  "css:build": "lessc src/less/main.less www/css/app.css",
  "css:watch": "watch 'npm run css:build' src/less/ -du",
}
```

TBH, I am only looking for the ignoreDotFiles to keep my build quiet when using vim...changes to swap (every keypress) forces the build...I noticed that ignoreUnreadableDir was also a boolean, so I just added that one as well. 

I :corn:sidered adding the other options, but thought that keeping with the already established simple CLI makes more sense then adding options that are better suited in a programatic environment (well for `ignoreDirectoryPattern `, as `filter` makes no sense in the command line).

Thoughts?