### PR TITLE
Add ability for CLI to watch multiple directories

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ var execshell = require('exec-sh')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [directory[, ...directory]] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable]')
+  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable]')
   process.exit()
 }
 

--- a/cli.js
+++ b/cli.js
@@ -5,13 +5,24 @@ var execshell = require('exec-sh')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable]')
+  console.error('Usage: watch <command> [directory[, ...directory]] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable]')
   process.exit()
 }
 
 var watchTreeOpts = {}
 var command = argv._[0]
-var dir = argv._[1] || process.cwd()
+var dirs = []
+
+var i
+var argLen = argv._.length
+if (argLen > 1) {
+  for(i = 1; i< argLen; i++) {
+      dirs.push(argv._[i])
+  }
+} else {
+  dirs.push(process.cwd())
+}
+
 var waitTime = Number(argv.wait || argv.w)
 
 if(argv.ignoreDotFiles || argv.d)
@@ -20,19 +31,27 @@ if(argv.ignoreDotFiles || argv.d)
 if(argv.ignoreUnreadable || argv.u)
   watchTreeOpts.ignoreUnreadableDir = true
 
-console.error('> Watching', dir)
-
 var wait = false
 
-watch.watchTree(dir, watchTreeOpts, function (f, curr, prev) {
-  if(wait) return
+var dirLen = dirs.length
+var skip = dirLen - 1
+for(i = 0; i < dirLen; i++) {
+  var dir = dirs[i]
+  console.error('> Watching', dir)
+  watch.watchTree(dir, watchTreeOpts, function (f, curr, prev) {
+    if(skip) {
+        skip--
+        return
+    }
+    if(wait) return
 
-  execshell(command)
+    execshell(command)
 
-  if(waitTime > 0) {
-    wait = true
-    setTimeout(function () {
-      wait = false
-    }, waitTime * 1000)
-  }
-})
+    if(waitTime > 0) {
+      wait = true
+      setTimeout(function () {
+        wait = false
+      }, waitTime * 1000)
+    }
+  })
+}

--- a/readme.mkd
+++ b/readme.mkd
@@ -87,7 +87,7 @@ This module includes a simple command line interface, which you can install with
 
 
 ```
-Usage: watch <command> [directory] [OPTIONS]
+Usage: watch <command> [...directory] [OPTIONS]
 
 OPTIONS:
     --wait=<seconds>
@@ -103,4 +103,4 @@ OPTIONS:
         watch [directory].
 ```
 
-It will watch the given directory (defaults to the current working directory) with `watchTree` and run the given command every time a file changes.
+It will watch the given directories (defaults to the current working directory) with `watchTree` and run the given command every time a file changes.


### PR DESCRIPTION
This is accomplished in two parts

* Uses an array of directories from the arguments rather than a single directory
* The current CLI behavior is to run the command at the beginning as well as any time a file changes in the directory. By running one watchTree call per directory, this causes the most likely unwanted behavior of running the command once per directory watched. This is fixed by skipping running the command all but one time.

Happy to make any modifications/improvements.