### PR TITLE
Add glob --filter(-f) argument to cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,10 +2,11 @@
 
 var argv = require('minimist')(process.argv.slice(2))
 var execshell = require('exec-sh')
+var minimatch = require('minimatch')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable]')
+  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable] [--filter=<glob>]')
   process.exit()
 }
 
@@ -30,6 +31,13 @@ if(argv.ignoreDotFiles || argv.d)
 
 if(argv.ignoreUnreadable || argv.u)
   watchTreeOpts.ignoreUnreadableDir = true
+
+var pattern = argv.filter || argv.f
+if(pattern) {
+  watchTreeOpts.filter = function(filename) {
+    return minimatch(filename, pattern)
+  }
+}
 
 var wait = false
 

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ var minimatch = require('minimatch')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable] [--filter=<glob>]')
+  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable] [--filter=<pattern>]')
   process.exit()
 }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "main": "./main",
   "dependencies": {
     "exec-sh": "^0.2.0",
+    "minimatch": "^2.0.4",
     "minimist": "^1.1.0"
   }
 }

--- a/readme.mkd
+++ b/readme.mkd
@@ -98,9 +98,14 @@ OPTIONS:
     --ignoreDotFiles, -d
         Ignores dot or hidden files in the watch [directory].
 
-     --ignoreUnreadable, -u
+    --ignoreUnreadable, -u
         Silently ignores files that cannot be read within the
         watch [directory].
+
+    --filter,-f=<pattern>
+        Watches only files matching a <pattern>. You need to
+        quote the <pattern> to prevent shell globbing.
+        e.g "*.js"
 ```
 
 It will watch the given directories (defaults to the current working directory) with `watchTree` and run the given command every time a file changes.


### PR DESCRIPTION
Add filter argument to cli. `--filter` argument is a glob pattern which will be matched against the changed file. If the pattern matches to the changed file, specified command will be executed.

Example usage:

    watch "echo test" ./src --filter "*.js"

Which will echo `test` when any *.js file changes under *./src*