### PR TITLE
fix keywords package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "watch",
   "description": "Utilities for watching file trees.",
-  "tags": [
+  "keywords": [
     "util",
     "utility",
     "fs",


### PR DESCRIPTION
I think that npm search engine needs valid tags/keywords in package.json to be searchable, because this package doesn't appear in the search results. Take the following search as proof.

https://www.npmjs.com/search?q=watch