### PR TITLE
Fixing arguments splitting problem on windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-
-var argv = require('minimist')(process.argv.slice(2))
+var arguments = require('splitArgs')(process.argv.slice(2).join(' '))
+var argv = require('minimist')(arguments)
 var execshell = require('exec-sh')
 var watch = require('./main.js')
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "main": "./main",
   "dependencies": {
     "exec-sh": "^0.2.0",
-    "minimist": "^1.1.0"
+    "minimist": "^1.1.0",
+    "splitargs": "0.0.3"
   }
 }


### PR DESCRIPTION
When watching on windows (8.1) arguments are handled incorrectly.

For example, for the following configuration in `package.json` 

```
  "watch": "watch 'npm run css' ./src"
```

the command will be `npm` and directories are `run` , `css` and `./src`.

Fixed the incorrect behaviour by adding `splitargs`.
