### PR TITLE
Add --filter=<some-watch-filter.js> c-l argument.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ var path = require('path')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--filter=<module>] [--ignoreDotFiles] [--ignoreUnreadable]')
+  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--filter=<file>] [--ignoreDotFiles] [--ignoreUnreadable]')
   process.exit()
 }
 

--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,7 @@
 
 var argv = require('minimist')(process.argv.slice(2))
 var execshell = require('exec-sh')
+var path = require('path')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
@@ -33,7 +34,7 @@ if(argv.ignoreUnreadable || argv.u)
 
 if(argv.filter || argv.f) {
   try {
-    watchTreeOpts.filter = require(argv.filter || argv.f)
+    watchTreeOpts.filter = require(path.resolve(process.cwd(), argv.filter || argv.f))
   } catch (e) {
     console.error(e)
     process.exit(1)

--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ var execshell = require('exec-sh')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable]')
+  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--filter=<module>] [--ignoreDotFiles] [--ignoreUnreadable]')
   process.exit()
 }
 
@@ -30,6 +30,15 @@ if(argv.ignoreDotFiles || argv.d)
 
 if(argv.ignoreUnreadable || argv.u)
   watchTreeOpts.ignoreUnreadableDir = true
+
+if(argv.filter || argv.f) {
+  try {
+    watchTreeOpts.filter = require(argv.filter || argv.f)
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+}
 
 var wait = false
 

--- a/readme.mkd
+++ b/readme.mkd
@@ -95,6 +95,11 @@ OPTIONS:
         after running <command>. Setting this option will
         throttle calls to <command> for the specified duration.
 
+    --filter=<file>
+        Path to a require-able .js file that exports a filter
+        function to be passed to watchTreeOptions.filter.
+        Path is resolved relative to process.cwd().
+
     --ignoreDotFiles, -d
         Ignores dot or hidden files in the watch [directory].
 


### PR DESCRIPTION
watchTreeOpt.filter is pretty useful, but not accessible from the `watch` c-l.

This PR adds a `--filter=<some-watch-filter.js>` argument, where `some-watch-filter.js` is a filepath relative to `process.cwd()` that exports a filter function `boolean ƒ()` as defined in the watchTreeOpt.filter documentation. 