### PR TITLE
Added the ignoreDirectoryPattern option to CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ var path = require('path')
 var watch = require('./main.js')
 
 if(argv._.length === 0) {
-  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--filter=<file>] [--ignoreDotFiles] [--ignoreUnreadable]')
+  console.error('Usage: watch <command> [...directory] [--wait=<seconds>] [--filter=<file>] [--ignoreDotFiles] [--ignoreUnreadable] [--ignoreDirectoryPattern]')
   process.exit()
 }
 
@@ -31,6 +31,11 @@ if(argv.ignoreDotFiles || argv.d)
 
 if(argv.ignoreUnreadable || argv.u)
   watchTreeOpts.ignoreUnreadableDir = true
+
+if(argv.ignoreDirectoryPattern || argv.p) {
+  var match = (argv.ignoreDirectoryPattern || argv.p).match(/\/(.*)\/([gimuy])/);
+  watchTreeOpts.ignoreDirectoryPattern = new RegExp(match[1], match[2])
+}
 
 if(argv.filter || argv.f) {
   try {

--- a/cli.js
+++ b/cli.js
@@ -33,7 +33,7 @@ if(argv.ignoreUnreadable || argv.u)
   watchTreeOpts.ignoreUnreadableDir = true
 
 if(argv.ignoreDirectoryPattern || argv.p) {
-  var match = (argv.ignoreDirectoryPattern || argv.p).match(/\/(.*)\/([gimuy])/);
+  var match = (argv.ignoreDirectoryPattern || argv.p).match(/^\/(.*)\/([gimuy])$/);
   watchTreeOpts.ignoreDirectoryPattern = new RegExp(match[1], match[2])
 }
 

--- a/readme.mkd
+++ b/readme.mkd
@@ -106,6 +106,10 @@ OPTIONS:
      --ignoreUnreadable, -u
         Silently ignores files that cannot be read within the
         watch [directory].
+
+     --ignoreDirectoryPattern=<regexp>, -p
+        Silently skips directories that match the regular
+        expression.
 ```
 
 It will watch the given directories (defaults to the current working directory) with `watchTree` and run the given command every time a file changes.


### PR DESCRIPTION
Added the ignoreDirectoryPattern option to CLI.

It takes a regular expression in the form of `/exp/i` and does a little bit of parsing to separate the pattern from the flags, so both can be used.