### PR TITLE
Add more robust release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "watch",
   "description": "Utilities for watching file trees.",
+  "scripts": {
+    "release:major": "bash scripts/release.sh major",
+    "release:minor": "bash scripts/release.sh minor",
+    "release:patch": "bash scripts/release.sh patch"
+  },
   "keywords": [
     "util",
     "utility",

--- a/readme.mkd
+++ b/readme.mkd
@@ -113,3 +113,15 @@ OPTIONS:
 ```
 
 It will watch the given directories (defaults to the current working directory) with `watchTree` and run the given command every time a file changes.
+
+## Contributing
+
+### Releasing
+
+On the latest clean `master`:
+
+```
+npm run release:major
+npm run release:minor
+npm run release:patch
+```

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-npm version minor && npm publish && npm version patch && git push --tags && git push origin master

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# require npm user
+# bump package version
+# commit
+# create tag
+# push commit & tag
+# publish
+
+usage() {
+  echo ""
+  echo "  Usage: bash $0 <major|minor|patch>"
+}
+
+run() {
+  local version=$1
+  local collaborators=$(npm access ls-collaborators)
+  local npm_user=$(npm whoami 2>/dev/null || "false")
+  local is_collaborator=$(echo "$collaborators" | grep ".*$npm_user.*:.*write.*" && "true" || "false")
+
+  if [[ "$npm_user" ]]; then
+    if [[ "$is_collaborator" ]]; then
+      echo "Publishing new $version version as $npm_user."
+      echo ""
+      npm version ${version}
+      git push
+      git push --follow-tags
+      npm publish
+    else
+      echo "$npm_user does not have NPM write access. Request access from one of these fine folk:"
+      echo ""
+      npm owner ls
+    fi
+  else
+    echo "You must be logged in to NPM to publish, run \"npm login\" first."
+  fi
+}
+
+case $1 in
+  "major" | "minor" | "patch")
+    run $1
+  ;;
+
+  *)
+    usage
+    exit 1
+  ;;
+esac


### PR DESCRIPTION
The current release script always increments the minor to publish.  Then it increments the patch but only pushes to github.

The new scripts allow for releasing major, minor, or patch explicitly.  Additionally, there are safeguards if you're not logged into NPM or if you do not have write access as a collaborator.  These prevent you from accidentally bumping/tagging/committing/pushing and then failing on publish.

## Not logged in
When not logged in, prevent bump/tag/commit/push success with publish fail:

```
› npm logout
› npm run release:patch

You must be logged into NPM to publish, run "npm login" first.
```

## No write access
When not a contributor with write access, prevent bump/tag/commit/push success with publish fail:

```
› npm run release:patch

fakeuser does not have NPM write access. Request access from one of these fine folk:

finnpauls <derfinn@gmail.com>
levithomason <me@levithomason.com>
mikeal <mikeal.rogers@gmail.com>
```

## All is well

If all is well, go for it:

```
› npm run release:patch

Publishing new patch version as levithomason.

npm version patch
git push
git push --follow-tags
npm publish
```

***

## Prevent bad direct use

The bash release script will not be used directly, however, if it is used directly and improperly then it will show the proper usage:

```bash
› bash scripts/release.sh invalid-version

  Usage: bash scripts/release.sh <major|minor|patch>
```