### PR TITLE
fix(watchTree): convert options.interval to seconds

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,6 +69,8 @@ var watchedFiles = Object.create(null);
 
 exports.watchTree = function ( root, options, callback ) {
   if (!callback) {callback = options; options = {}}
+  // convert interval to seconds
+  if (options.interval) {options.interval = options.interval * 1000}
   walk(root, options, function (err, files) {
     if (err) throw err;
     var fileWatcher = function (f) {


### PR DESCRIPTION
Fixes #112.  `interval` was only converted to seconds through the CLI.  There should be some higher order `parseOptions` added to handle this kind of thing.

This at least fixes the issue for the time being.

@mikeal review?