### PR TITLE
fix(cli): pass interval in seconds

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,7 +34,7 @@ if (argLen > 1) {
 
 var waitTime = Number(argv.wait || argv.w)
 if (argv.interval || argv.i) {
-  watchTreeOpts.interval = Number(argv.interval || argv.i || 0.2) * 1000.0;
+  watchTreeOpts.interval = Number(argv.interval || argv.i || 0.2);
 }
 
 if(argv.ignoreDotFiles || argv.d)


### PR DESCRIPTION
Fixes bug introduced in v1.0.0, where the CLI converts the interval arg to seconds but the watchTree is also converting to seconds.  So, intervals are in 1000s increments.

Tested the issue to confirm.  Tested the solution to confirm as well.