### PR TITLE
Don't mutate the original options

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,12 +69,14 @@ var watchedFiles = Object.create(null);
 
 exports.watchTree = function ( root, options, callback ) {
   if (!callback) {callback = options; options = {}}
-  // convert interval to seconds
-  if (options.interval) {options.interval = options.interval * 1000}
   walk(root, options, function (err, files) {
     if (err) throw err;
     var fileWatcher = function (f) {
-      fs.watchFile(f, options, function (c, p) {
+      var fsOptions = {};
+      if (options.interval) {
+        fsOptions.interval = options.interval * 1000;
+      }
+      fs.watchFile(f, fsOptions, function (c, p) {
         // Check if anything actually changed in stat
         if (files[f] && !files[f].isDirectory() && c.nlink !== 0 && files[f].mtime.getTime() == c.mtime.getTime()) return;
         files[f] = c;


### PR DESCRIPTION
A bug was introduced by #113.

If you watch multiple directories then the same options object is passed from CLI to `watchTree` multiple times. `watchTree` mutates the `options.interval` each time. This results in the actual interval becoming 1000x higher that it should for two directories, 1000000x for three and so on.

The best fix is to pass a new options object to `fs.watchFile()` which is calculated from the original.