### PR TITLE
Updated exec-sh package to latest which fixes a known vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "main": "./main",
   "dependencies": {
-    "exec-sh": "^0.2.0",
+    "exec-sh": "^0.3.2",
     "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
The exec-sh package used a package with a disclosed security vulnerability, see https://hackerone.com/reports/381194.

This has now been removed in the latest version 0.3.2
