### PR TITLE
update minimist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "main": "./main",
   "dependencies": {
     "exec-sh": "^0.2.0",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.3"
   }
 }


### PR DESCRIPTION
minimist  before 1.2.2 could be tricked into adding or modifying properties of  Object.prototype using a "constructor" or "__proto__" payload.


