### PR TITLE
fix: eleminate exec-sh vulnerability by removing the dependnecy with minimal substitution

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var argv = require('minimist')(process.argv.slice(2))
-var execshell = require('exec-sh')
+var execshell = require("./shell.js").exec
 var path = require('path')
 var watch = require('./main.js')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "watch",
+  "version": "1.0.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "watch",
+      "version": "1.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "watch": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.1.95"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "main": "./main",
   "dependencies": {
-    "exec-sh": "^0.2.0",
     "minimist": "^1.2.0"
   }
 }

--- a/shell.js
+++ b/shell.js
@@ -1,8 +1,6 @@
 var cp = require("child_process")
-console.log("shell.js")
 
 function getShell() {
-  console.log("getShell")
   if (process.platform === "win32") {
     return { cmd: "cmd", arg: "/C" }
   } else {

--- a/shell.js
+++ b/shell.js
@@ -1,0 +1,19 @@
+var cp = require("child_process")
+console.log("shell.js")
+
+function getShell() {
+  console.log("getShell")
+  if (process.platform === "win32") {
+    return { cmd: "cmd", arg: "/C" }
+  } else {
+    return { cmd: "sh", arg: "-c" }
+  }
+}
+
+function exec(command) {
+  var shell = getShell()
+  var child = cp.spawn(shell.cmd, [shell.arg, command], { stdio: "inherit" })
+  return child
+}
+
+exports.exec = exec


### PR DESCRIPTION
This fixes the current *high* Severity vulnerability that npm is reporting for those of us having dependencies on this package. The fix is completed by a small patch that removes exec-sh. Please let me know if there is anything I could do to make this an acceptable merge for the maintainers.

Below is what npm is currently reporting for me when depending on this package:
```
merge  <2.1.1
Severity: high
Prototype Pollution in merge - https://github.com/advisories/GHSA-7wpw-2hjm-89gp
fix available via `npm audit fix --force`
Will install watch@0.13.0, which is a breaking change
node_modules/merge
  exec-sh  <=0.3.1
  Depends on vulnerable versions of merge
  node_modules/exec-sh
    watch  >=0.14.0
    Depends on vulnerable versions of exec-sh
    node_modules/watch
```